### PR TITLE
Update U of Toronto in school list

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Summary of schools using Racket (from GitHub page) vs. Python (from [Guo](http:/
 | Racket Schools        | Python Schools  |
 |-----------------------|-----------------|
 | Yale                  | CMU             |
-| U of Toronto          | MIT             |
+| Brown                 | MIT             |
 | Northwestern          | UC Berkeley     |
 | Grinnell              | Cornell         |
 | Berry College         | U of Washington |
@@ -84,7 +84,7 @@ Summary of schools using Racket (from GitHub page) vs. Python (from [Guo](http:/
 | U of Utah             | UT Austin       |
 | U of British Columbia | Caltech         |
 | U Chicago             | U Michigan      |
-| Brown                 | Columbia        |
+|                       | Columbia        |
 |                       | Purdue          |
 |                       | Rice            |
 |                       | USC             |
@@ -96,6 +96,7 @@ Summary of schools using Racket (from GitHub page) vs. Python (from [Guo](http:/
 |                       | UVA             |
 |                       | UCSB            |
 |                       | UC Davis        |
+|                       | U of Toronto    |
 |                       |                 |
 
 * Did I get your school wrong? Sorry! Some of this data might be out-of-date. Please make [a pull request](https://github.com/acbart/ihateracket.com/pulls) with a link to a public syllabus or course website, and I'll happily accept all updates! I'm not trying to really keep track of this closely, I just wanted to get a sample of where the world's at right now. But I also don't want to purvey false data!


### PR DESCRIPTION
This site came up on HN today, and I figured I'd send in a PR to place UofT in the right column :)

CS1 has been taught in Python at least for my undergrad/the last 4 years ([recent syllabus](https://mcs.utm.utoronto.ca/~108s20/)). Racket remains used in introductory PL courses.